### PR TITLE
add tracing support with Datadog APM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Datadog plugin for Caddy HTTP/2 web server
 
-Datadog plugin allow Caddy HTTP/2 web server to send some metrics to Datadog via statsd.
+Datadog plugin allow Caddy HTTP/2 web server to send some metrics to Datadog via statsd, and optionally also send traces to Datadog APM.
 *****
 
 
@@ -16,10 +16,12 @@ In the following example, all requests on _example-d.com_ won't be harvested.
     }
 
     example-b.com {
-      datadog "area" {            # area is optional
-        statsd    127.0.0.1:8125  # Optional - can be any valid hostname with port
-        tags      tag1 tag2 tagN  # Optional
-        namespace caddy.          # Optional
+      datadog "area" {                # area is optional
+        statsd        127.0.0.1:8125  # Optional - can be any valid hostname with port
+        tags          tag1 tag2 tagN  # Optional
+        namespace     caddy.          # Optional
+        trace_enabled                 # Optional - whether to enable tracing to Datadog APM
+        trace_agent   127.0.0.1:8126  # Optional - can be any valid hostname with port
       }
     }
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ In the following example, all requests on _example-d.com_ won't be harvested.
         namespace     caddy.          # Optional
         trace_enabled                 # Optional - whether to enable tracing to Datadog APM
         trace_agent   127.0.0.1:8126  # Optional - can be any valid hostname with port
+        service_name  caddy           # Optional
       }
     }
 

--- a/datadog.go
+++ b/datadog.go
@@ -177,7 +177,7 @@ func initializeDatadogHQ(controller *caddy.Controller) error {
 					traceEnabled = true
 				}
 				if err != nil {
-					return controller.Err("datadog: not a valid boolean value for trace enabled")
+					return controller.Err("datadog: not a valid boolean value for trace_enabled")
 				}
 			case "trace_agent":
 				var args = controller.RemainingArgs()
@@ -187,7 +187,7 @@ func initializeDatadogHQ(controller *caddy.Controller) error {
 					traceAgent = TRACE_AGENT
 				}
 				if !hostnameRegex.MatchString(traceAgent) {
-					return controller.Err("datadog: not a valid address. Must be <hostname>:<port>")
+					return controller.Err("datadog: not a valid trace_agent address. Must be <hostname>:<port>")
 				}
 			}
 		}

--- a/handler.go
+++ b/handler.go
@@ -38,7 +38,6 @@ func (datadog DatadogModule) ServeHTTP(responseWriter http.ResponseWriter, reque
 	responseRecorder := httpserver.NewResponseRecorder(responseWriter)
 	spanContext, _ := tracer.Extract(tracer.HTTPHeadersCarrier(request.Header))
 	spanOptions := []ddtrace.StartSpanOption{
-		tracer.ServiceName("caddy"),         // TODO: change this to a more useful service name
 		tracer.ResourceName(request.Method), // TODO: change this to a more useful resource name
 		tracer.SpanType(ext.SpanTypeWeb),
 		tracer.ChildOf(spanContext),

--- a/handler.go
+++ b/handler.go
@@ -25,6 +25,9 @@ package caddy_datadog
 
 import (
 	"github.com/mholt/caddy/caddyhttp/httpserver"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -33,6 +36,16 @@ import (
 func (datadog DatadogModule) ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) (int, error) {
 	timeStart := time.Now()
 	responseRecorder := httpserver.NewResponseRecorder(responseWriter)
+	spanContext, _ := tracer.Extract(tracer.HTTPHeadersCarrier(request.Header))
+	spanOptions := []ddtrace.StartSpanOption{
+		tracer.ServiceName("caddy"),         // TODO: change this to a more useful service name
+		tracer.ResourceName(request.Method), // TODO: change this to a more useful resource name
+		tracer.SpanType(ext.SpanTypeWeb),
+		tracer.ChildOf(spanContext),
+		tracer.Tag(ext.HTTPMethod, request.Method),
+		tracer.Tag(ext.HTTPURL, request.URL.Path),
+	}
+	span := tracer.StartSpan("caddy.request", spanOptions...)
 	status, err := datadog.Next.ServeHTTP(responseRecorder, request)
 	atomic.AddUint64(&datadog.Metrics.responseTime, uint64(time.Since(timeStart).Nanoseconds()))
 
@@ -40,6 +53,10 @@ func (datadog DatadogModule) ServeHTTP(responseWriter http.ResponseWriter, reque
 	if realStatus == 0 {
 		realStatus = responseRecorder.Status()
 	}
+
+	span.SetTag(ext.HTTPCode, realStatus)
+	span.SetTag(ext.Error, err)
+	span.Finish()
 
 	atomic.AddUint64(&datadog.Metrics.responseSize, uint64(responseRecorder.Size()))
 	switch realStatus / 100 {
@@ -59,5 +76,6 @@ func (datadog DatadogModule) ServeHTTP(responseWriter http.ResponseWriter, reque
 		atomic.AddUint64(&datadog.Metrics.response5xxCount, 1)
 		break
 	}
+
 	return status, err
 }

--- a/handler.go
+++ b/handler.go
@@ -46,6 +46,7 @@ func (datadog DatadogModule) ServeHTTP(responseWriter http.ResponseWriter, reque
 		tracer.Tag(ext.HTTPURL, request.URL.Path),
 	}
 	span := tracer.StartSpan("caddy.request", spanOptions...)
+	tracer.Inject(span.Context(), tracer.HTTPHeadersCarrier(request.Header))
 	status, err := datadog.Next.ServeHTTP(responseRecorder, request)
 	atomic.AddUint64(&datadog.Metrics.responseTime, uint64(time.Since(timeStart).Nanoseconds()))
 


### PR DESCRIPTION
This PR adds support for tracing using Datadog APM.

Closes #6 

There are a few improvements that I would like to make but I am not very familiar with Caddy, so any help appreciated.

**Help Wanted 1**: Scope all configuration related to APM under its own block, for example:

```
example-b.com {
  datadog "area" {                # area is optional
    statsd        127.0.0.1:8125  # Optional - can be any valid hostname with port
    tags          tag1 tag2 tagN  # Optional
    namespace     caddy.          # Optional
    apm {
      enabled                 # Optional - whether to enable tracing to Datadog APM
      agent    127.0.0.1:8126 # Optional - can be any valid hostname with port
      service  caddy          # Optional
    }
  }
}
```

Right now I used more explicit names because I don't know how to do the above.

**Help Wanted 2**: Use any route defined on the `proxy` directive, or other relevant information as the resource name.

Right now I always set the resource name to always be the HTTP method only as I don't know how to grab any more useful information to include.